### PR TITLE
Add customizable welcome screen with settings

### DIFF
--- a/BnbTV/BnbTV/ContentView.swift
+++ b/BnbTV/BnbTV/ContentView.swift
@@ -7,18 +7,85 @@
 
 import SwiftUI
 
+/// Represents the buttons shown along the bottom of the home screen.
+enum HomeAction: String, CaseIterable, Identifiable {
+    case wifi = "WiFi Password"
+    case rules = "House Rules"
+    case around = "Things Around Here"
+    case howTo = "How To"
+    case checkout = "Check Out"
+    case tvGuide = "TV Guide"
+    case localEats = "Local Eats"
+    case emergency = "Emergency Contacts"
+
+    var id: String { rawValue }
+}
+
+/// Maps a stored background name to a concrete `Color` value.
+private func colorFromName(_ name: String) -> Color {
+    switch name {
+    case "Green":
+        return .green
+    case "Orange":
+        return .orange
+    case "Gray":
+        return .gray
+    default:
+        return .blue
+    }
+}
+
 struct ContentView: View {
+    @AppStorage("userName") private var userName: String = "Guest"
+    @AppStorage("backgroundColor") private var backgroundColorName: String = "Blue"
+
+    private let actions = HomeAction.allCases
+
     var body: some View {
-        VStack {
-            Image(systemName: "globe")
-                .imageScale(.large)
-                .foregroundStyle(.tint)
-            Text("Hello, world!")
+        NavigationStack {
+            ZStack(alignment: .topTrailing) {
+                colorFromName(backgroundColorName)
+                    .ignoresSafeArea()
+
+                VStack(alignment: .leading, spacing: 40) {
+                    Text("Welcome")
+                        .font(.system(size: 80, weight: .bold))
+                    Text(userName)
+                        .font(.system(size: 60, weight: .semibold))
+
+                    Spacer()
+
+                    ScrollView(.horizontal, showsIndicators: false) {
+                        HStack(spacing: 40) {
+                            ForEach(actions) { action in
+                                Button(action.rawValue) {}
+                                    .frame(width: 400, height: 120)
+                                    .background(Color.white.opacity(0.3))
+                                    .cornerRadius(20)
+                            }
+                        }
+                        .padding(.horizontal)
+                    }
+
+                    Text("Swipe to see more")
+                        .font(.footnote)
+                        .padding(.leading)
+
+                    Spacer().frame(height: 40)
+                }
+                .padding(.leading, 80)
+
+                NavigationLink(destination: SettingsView()) {
+                    Image(systemName: "gearshape")
+                        .font(.system(size: 40))
+                        .padding()
+                }
+            }
         }
-        .padding()
     }
 }
 
 #Preview {
     ContentView()
 }
+

--- a/BnbTV/BnbTV/SettingsView.swift
+++ b/BnbTV/BnbTV/SettingsView.swift
@@ -1,0 +1,38 @@
+//
+//  SettingsView.swift
+//  BnbTV
+//
+//  Created by PayneBrain on 8/27/25.
+//
+
+import SwiftUI
+
+struct SettingsView: View {
+    @AppStorage("userName") private var userName: String = "Guest"
+    @AppStorage("backgroundColor") private var backgroundColorName: String = "Blue"
+
+    private let colors = ["Blue", "Green", "Orange", "Gray"]
+
+    var body: some View {
+        Form {
+            Section("Name") {
+                TextField("Name", text: $userName)
+            }
+
+            Section("Background") {
+                Picker("Background", selection: $backgroundColorName) {
+                    ForEach(colors, id: \.self) { color in
+                        Text(color)
+                    }
+                }
+                .pickerStyle(.wheel)
+            }
+        }
+        .navigationTitle("Settings")
+    }
+}
+
+#Preview {
+    SettingsView()
+}
+


### PR DESCRIPTION
## Summary
- Implement welcome screen with personalized name and dynamic background color.
- Add settings view allowing name and background customization.
- Introduce horizontal scroll of eight action buttons with swipe instructions.

## Testing
- ❌ `xcodebuild -list` (command not found)


------
https://chatgpt.com/codex/tasks/task_e_68b00886ebb8832ba6b81a05bf96d8d0