### PR TITLE
Fetch remote configuration for screens

### DIFF
--- a/BnbTV/BnbTV/BnbTVApp.swift
+++ b/BnbTV/BnbTV/BnbTVApp.swift
@@ -9,9 +9,15 @@ import SwiftUI
 
 @main
 struct BnbTVApp: App {
+    @StateObject private var configManager = ConfigManager()
+
     var body: some Scene {
         WindowGroup {
             ContentView()
+                .environmentObject(configManager)
+                .task {
+                    await configManager.load()
+                }
         }
     }
 }

--- a/BnbTV/BnbTV/ConfigManager.swift
+++ b/BnbTV/BnbTV/ConfigManager.swift
@@ -1,0 +1,40 @@
+import Foundation
+
+@MainActor
+class ConfigManager: ObservableObject {
+    @Published private(set) var config: RemoteConfig?
+    private let configURL = URL(string: "https://www.paynebrain.com/appletvconfig.json")!
+
+    func load() async {
+        do {
+            let (data, _) = try await URLSession.shared.data(from: configURL)
+            let decoder = JSONDecoder()
+            decoder.dateDecodingStrategy = .iso8601
+            let remote = try decoder.decode(RemoteConfig.self, from: data)
+            apply(config: remote)
+        } catch {
+            print("Failed to load config: \(error)")
+        }
+    }
+
+    func screen(ofType type: RemoteConfig.Screen.ScreenType) -> RemoteConfig.Screen? {
+        return config?.screens.first { $0.type == type }
+    }
+
+    private func apply(config: RemoteConfig) {
+        self.config = config
+        let defaults = UserDefaults.standard
+        defaults.set(config.guest.displayName, forKey: "userName")
+
+        if let rules = screen(ofType: .rules) {
+            if let items = rules.items {
+                defaults.set(items.joined(separator: "\n"), forKey: "houseRules")
+            } else if let body = rules.body {
+                defaults.set(body, forKey: "houseRules")
+            }
+        }
+
+        defaults.set(config.wifi.ssid, forKey: "wifiSSID")
+        defaults.set(config.wifi.password, forKey: "wifiPassword")
+    }
+}

--- a/BnbTV/BnbTV/ContentView.swift
+++ b/BnbTV/BnbTV/ContentView.swift
@@ -44,6 +44,7 @@ struct ContentView: View {
     @AppStorage("zipCode") private var zipCode: String = ""
     @AppStorage("homeMusic") private var homeMusicName: String = ""
     @AppStorage("buttonColor") private var buttonColorName: String = "transparentGrey"
+    @EnvironmentObject private var configManager: ConfigManager
 
     @State private var weather: WeatherData?
     @State private var currentDate: Date = Date()
@@ -66,10 +67,21 @@ struct ContentView: View {
                     .ignoresSafeArea()
 
                 VStack(alignment: .leading, spacing: 40) {
-                    Text("Welcome")
-                        .font(.system(size: 80, weight: .bold))
-                    Text(userName)
-                        .font(.system(size: 60, weight: .semibold))
+                    if let welcome = configManager.screen(ofType: .welcome) {
+                        Text(welcome.title)
+                            .font(.system(size: 80, weight: .bold))
+                        Text(userName)
+                            .font(.system(size: 60, weight: .semibold))
+                        if let body = welcome.body {
+                            Text(body)
+                                .font(.title2)
+                        }
+                    } else {
+                        Text("Welcome")
+                            .font(.system(size: 80, weight: .bold))
+                        Text(userName)
+                            .font(.system(size: 60, weight: .semibold))
+                    }
 
                     Spacer()
 
@@ -172,7 +184,35 @@ struct ContentView: View {
     private func destinationView(for action: HomeAction) -> some View {
         switch action {
         case .rules:
-            HouseRulesView()
+            if let screen = configManager.screen(ofType: .rules) {
+                ScreenView(screen: screen)
+            } else {
+                HouseRulesView()
+            }
+        case .wifi:
+            if let screen = configManager.screen(ofType: .wifi) {
+                ScreenView(screen: screen)
+            } else {
+                PlaceholderView(title: action.rawValue)
+            }
+        case .howTo:
+            if let screen = configManager.screen(ofType: .howto) {
+                ScreenView(screen: screen)
+            } else {
+                PlaceholderView(title: action.rawValue)
+            }
+        case .checkout:
+            if let screen = configManager.screen(ofType: .checkout) {
+                ScreenView(screen: screen)
+            } else {
+                PlaceholderView(title: action.rawValue)
+            }
+        case .emergency:
+            if let screen = configManager.screen(ofType: .contacts) {
+                ScreenView(screen: screen)
+            } else {
+                PlaceholderView(title: action.rawValue)
+            }
         default:
             PlaceholderView(title: action.rawValue)
         }

--- a/BnbTV/BnbTV/RemoteConfig.swift
+++ b/BnbTV/BnbTV/RemoteConfig.swift
@@ -1,0 +1,49 @@
+import Foundation
+
+struct RemoteConfig: Decodable {
+    struct Guest: Decodable {
+        let displayName: String
+    }
+
+    struct Stay: Decodable {
+        let checkIn: String
+        let checkOut: String
+        let propertyName: String
+    }
+
+    struct Wifi: Decodable {
+        let ssid: String
+        let password: String
+    }
+
+    struct Theme: Decodable {
+        let accent: String
+        let backgroundImage: String
+    }
+
+    struct Screen: Decodable, Identifiable {
+        enum ScreenType: String, Decodable {
+            case welcome
+            case wifi
+            case rules
+            case howto
+            case checkout
+            case contacts
+        }
+
+        let id = UUID()
+        let type: ScreenType
+        let title: String
+        let body: String?
+        let items: [String]?
+    }
+
+    let version: Int
+    let validUntil: Date
+    let locale: String
+    let guest: Guest
+    let stay: Stay
+    let wifi: Wifi
+    let theme: Theme
+    let screens: [Screen]
+}

--- a/BnbTV/BnbTV/ScreenView.swift
+++ b/BnbTV/BnbTV/ScreenView.swift
@@ -1,0 +1,36 @@
+import SwiftUI
+
+struct ScreenView: View {
+    let screen: RemoteConfig.Screen
+    @AppStorage("wifiSSID") private var wifiSSID: String = ""
+    @AppStorage("wifiPassword") private var wifiPassword: String = ""
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 20) {
+                if screen.type == .wifi {
+                    Text("SSID: \(wifiSSID)")
+                    Text("Password: \(wifiPassword)")
+                }
+
+                if let body = screen.body {
+                    Text(body)
+                }
+
+                if let items = screen.items {
+                    ForEach(items, id: \.self) { item in
+                        Text("• \(item)")
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                    }
+                }
+            }
+            .padding()
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .navigationTitle(screen.title)
+    }
+}
+
+#Preview {
+    ScreenView(screen: RemoteConfig.Screen(type: .wifi, title: "Wi-Fi", body: "Sample", items: nil))
+}


### PR DESCRIPTION
## Summary
- load remote configuration from paynebrain.com and apply guest, wifi, and rules details
- expose configuration via ConfigManager and use it to populate home and secondary screens
- add generic ScreenView to display text or list content for each configured section

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68b035e9c928832b8452b339f9f248de