### PR TITLE
Improve tvOS UI for Settings and Home menu

### DIFF
--- a/BnbTV/BnbTV/ContentView.swift
+++ b/BnbTV/BnbTV/ContentView.swift
@@ -181,12 +181,38 @@ struct ContentView: View {
     private struct HomeButtonStyle: ButtonStyle {
         let color: Color
         func makeBody(configuration: Configuration) -> some View {
+            #if os(tvOS)
+            HomeButton(configuration: configuration, color: color)
+            #else
             configuration.label
                 .frame(width: 400, height: 220)
                 .background(color)
                 .overlay(Color.gray.opacity(configuration.isPressed ? 0.4 : 0))
                 .cornerRadius(20)
+            #endif
         }
+
+        #if os(tvOS)
+        private struct HomeButton: View {
+            let configuration: Configuration
+            let color: Color
+            @Environment(\.isFocused) private var isFocused
+
+            var body: some View {
+                configuration.label
+                    .frame(width: 400, height: 220)
+                    .background(color)
+                    .overlay(Color.gray.opacity(configuration.isPressed ? 0.4 : 0))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 20)
+                            .stroke(Color.white, lineWidth: isFocused ? 6 : 0)
+                    )
+                    .scaleEffect(isFocused ? 1.05 : 1.0)
+                    .cornerRadius(20)
+                    .animation(.easeInOut(duration: 0.1), value: isFocused)
+            }
+        }
+        #endif
     }
 
     private func playMusic() {

--- a/BnbTV/BnbTV/SettingsView.swift
+++ b/BnbTV/BnbTV/SettingsView.swift
@@ -119,8 +119,13 @@ struct SettingsView: View {
             }
 
             Section("House Rules") {
+#if os(tvOS)
+                TextField("House Rules", text: $houseRules)
+                    .frame(height: 150)
+#else
                 TextEditor(text: $houseRules)
                     .frame(height: 150)
+#endif
             }
 
             Section("Zip Code") {


### PR DESCRIPTION
## Summary
- Avoid tvOS build failures by using TextField for the house rules section when building on tvOS.
- Highlight focused home menu buttons on tvOS so the cursor location is visible.

## Testing
- `swift test` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*

------
https://chatgpt.com/codex/tasks/task_e_68b03151a2a4832b8ca2b79fcff7bbd9