### PR TITLE
Highlight focused home buttons

### DIFF
--- a/BnbTV/BnbTV/ContentView.swift
+++ b/BnbTV/BnbTV/ContentView.swift
@@ -50,6 +50,7 @@ struct ContentView: View {
     @State private var currentDate: Date = Date()
     @State private var audioPlayer: AVAudioPlayer?
     @Environment(\.scenePhase) private var scenePhase
+    @FocusState private var focusedAction: HomeAction?
 
     private let actions = HomeAction.allCases
     private let timer = Timer.publish(every: 60, on: .main, in: .common).autoconnect()
@@ -93,10 +94,11 @@ struct ContentView: View {
                                         Image(systemName: action.systemImage)
                                             .resizable()
                                             .scaledToFit()
-                                            .frame(height: 60)
+                                            .frame(height: focusedAction == action ? 80 : 60)
                                         Text(action.rawValue)
                                     }
                                 }
+                                .focused($focusedAction, equals: action)
                                 .buttonStyle(HomeButtonStyle(color: color(for: buttonColorName)))
                             }
                         }
@@ -220,10 +222,15 @@ struct ContentView: View {
 
     private struct HomeButtonStyle: ButtonStyle {
         let color: Color
+        @Environment(\.isFocused) private var isFocused: Bool
         func makeBody(configuration: Configuration) -> some View {
             configuration.label
                 .frame(width: 400, height: 220)
                 .background(color)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 20)
+                        .stroke(Color.white, lineWidth: isFocused ? 4 : 0)
+                )
                 .overlay(Color.gray.opacity(configuration.isPressed ? 0.4 : 0))
                 .cornerRadius(20)
         }


### PR DESCRIPTION
## Summary
- Enlarge and highlight home screen buttons when they gain focus for improved visual feedback
- Track focused action with `@FocusState` to scale icons when selected
- Add focus-aware button style to draw white border around focused buttons

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b1004a956c832b8861f73ef03607b2