### PR TITLE
Allow GIF backgrounds and refine weather UI

### DIFF
--- a/BnbTV/BnbTV/AnimatedGIFView.swift
+++ b/BnbTV/BnbTV/AnimatedGIFView.swift
@@ -1,0 +1,53 @@
+import SwiftUI
+import ImageIO
+import UIKit
+
+struct AnimatedGIFView: View {
+    let url: URL
+
+    var body: some View {
+        GeometryReader { proxy in
+            GIFImageView(url: url)
+                .frame(width: proxy.size.width, height: proxy.size.height)
+                .clipped()
+                .allowsHitTesting(false)
+#if os(tvOS)
+                .focusable(false)
+#endif
+        }
+    }
+}
+
+private struct GIFImageView: UIViewRepresentable {
+    let url: URL
+
+    func makeUIView(context: Context) -> UIImageView {
+        let imageView = UIImageView()
+        imageView.contentMode = .scaleAspectFill
+        imageView.clipsToBounds = true
+        imageView.image = animatedImage()
+        return imageView
+    }
+
+    func updateUIView(_ uiView: UIImageView, context: Context) {
+        uiView.image = animatedImage()
+    }
+
+    private func animatedImage() -> UIImage? {
+        guard let data = try? Data(contentsOf: url) else { return nil }
+        guard let source = CGImageSourceCreateWithData(data as CFData, nil) else { return nil }
+        let count = CGImageSourceGetCount(source)
+        var images: [UIImage] = []
+        var duration: TimeInterval = 0
+        for i in 0..<count {
+            if let cgImage = CGImageSourceCreateImageAtIndex(source, i, nil) {
+                images.append(UIImage(cgImage: cgImage))
+                let properties = CGImageSourceCopyPropertiesAtIndex(source, i, nil) as? [CFString: Any]
+                let gifDict = properties?[kCGImagePropertyGIFDictionary] as? [CFString: Any]
+                let frameDuration = gifDict?[kCGImagePropertyGIFUnclampedDelayTime] as? NSNumber ?? gifDict?[kCGImagePropertyGIFDelayTime] as? NSNumber ?? 0.1
+                duration += frameDuration.doubleValue
+            }
+        }
+        return UIImage.animatedImage(with: images, duration: duration)
+    }
+}

--- a/BnbTV/BnbTV/ContentView.swift
+++ b/BnbTV/BnbTV/ContentView.swift
@@ -99,11 +99,6 @@ struct ContentView: View {
                             .frame(width: titleWidth, alignment: .leading)
                     }
 
-                    if !forecast.isEmpty {
-                        WeatherCardView(forecast: forecast)
-                            .frame(width: titleWidth, alignment: .leading)
-                    }
-
                     Spacer()
 
                     ScrollView(.horizontal, showsIndicators: false) {
@@ -133,11 +128,11 @@ struct ContentView: View {
                 }
                 .padding(.leading, 80)
 
-                VStack(alignment: .trailing, spacing: 4) {
+                VStack(alignment: .trailing, spacing: 20) {
                     Text(timeString)
                         .font(.title3)
                     if let weather = weather {
-                        Text("\(weather.description) \(Int(weather.temperature))°F")
+                        Text("\(WeatherManager.emoji(for: weather.description)) \(Int(weather.temperature))°F")
                             .font(.footnote)
                     }
                     Button {
@@ -165,6 +160,11 @@ struct ContentView: View {
                     .alert("Incorrect Passcode", isPresented: $wrongPasscode) {}
                     NavigationLink("", destination: SettingsView(onDismiss: { playMusic() }), isActive: $showSettings)
                         .hidden()
+
+                    if !forecast.isEmpty {
+                        WeatherCardView(forecast: forecast)
+                            .frame(width: 450, alignment: .trailing)
+                    }
                 }
                 .padding()
             }
@@ -194,6 +194,9 @@ struct ContentView: View {
                } else if let url = videoURL(for: backgroundMediaName) {
                    LoopingVideoView(url: url)
                        .id(backgroundMediaName)
+               } else if let url = gifURL(for: backgroundMediaName) {
+                   AnimatedGIFView(url: url)
+                       .id(backgroundMediaName)
                } else if let image = UIImage(named: backgroundMediaName) {
                    Image(uiImage: image)
                        .resizable()
@@ -207,6 +210,13 @@ struct ContentView: View {
     private func videoURL(for name: String) -> URL? {
         let ext = (name as NSString).pathExtension.lowercased()
         guard ["mp4", "mov"].contains(ext) else { return nil }
+        let baseName = (name as NSString).deletingPathExtension
+        return Bundle.main.url(forResource: baseName, withExtension: ext)
+    }
+
+    private func gifURL(for name: String) -> URL? {
+        let ext = (name as NSString).pathExtension.lowercased()
+        guard ext == "gif" else { return nil }
         let baseName = (name as NSString).deletingPathExtension
         return Bundle.main.url(forResource: baseName, withExtension: ext)
     }

--- a/BnbTV/BnbTV/WeatherCardView.swift
+++ b/BnbTV/BnbTV/WeatherCardView.swift
@@ -11,7 +11,7 @@ struct WeatherCardView: View {
                 VStack(alignment: .leading, spacing: 8) {
                     Text(day.date, format: Date.FormatStyle().weekday(.abbreviated))
                         .font(.headline)
-                    Text(day.description)
+                    Text("\(WeatherManager.emoji(for: day.description)) \(day.description)")
                         .font(.subheadline)
                         .multilineTextAlignment(.leading)
                     Text("High: \(Int(day.high))°F")
@@ -20,7 +20,7 @@ struct WeatherCardView: View {
                 }
                 .padding()
                 .frame(width: 450, height: 220, alignment: .leading)
-                .background(Color.white.opacity(0.3))
+                .background(Color.blue.opacity(0.3))
                 .cornerRadius(10)
                 .tag(i)
             }

--- a/BnbTV/BnbTV/WeatherManager.swift
+++ b/BnbTV/BnbTV/WeatherManager.swift
@@ -69,6 +69,18 @@ actor WeatherManager {
         default: return "Unknown"
         }
     }
+
+    static func emoji(for description: String) -> String {
+        switch description {
+        case "Clear": return "☀️"
+        case "Clouds": return "☁️"
+        case "Fog": return "🌫"
+        case "Drizzle": return "🌦"
+        case "Rain": return "🌧"
+        case "Snow": return "❄️"
+        default: return "❓"
+        }
+    }
 }
 
 private struct GeoResponse: Decodable {


### PR DESCRIPTION
## Summary
- Support animated GIFs as selectable backgrounds
- Show weather emojis and move forecast card to the right with a translucent blue background

## Testing
- `swift test` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*


------
https://chatgpt.com/codex/tasks/task_e_68b302f87b1c832bbc183a40443584f8