### PR TITLE
Add weather icons and reposition forecast

### DIFF
--- a/BnbTV/BnbTV/ContentView.swift
+++ b/BnbTV/BnbTV/ContentView.swift
@@ -100,8 +100,11 @@ struct ContentView: View {
                     }
 
                     if !forecast.isEmpty {
-                        WeatherCardView(forecast: forecast)
-                            .frame(width: titleWidth, alignment: .leading)
+                        HStack {
+                            Spacer()
+                            WeatherCardView(forecast: forecast)
+                        }
+                        .frame(maxWidth: .infinity)
                     }
 
                     Spacer()
@@ -131,13 +134,14 @@ struct ContentView: View {
 
                     Spacer().frame(height: 40)
                 }
+                .frame(maxWidth: .infinity, alignment: .leading)
                 .padding(.leading, 80)
 
                 VStack(alignment: .trailing, spacing: 4) {
                     Text(timeString)
                         .font(.title3)
                     if let weather = weather {
-                        Text("\(weather.description) \(Int(weather.temperature))°F")
+                        Text("\(weatherEmoji(for: weather.description)) \(weather.description) \(Int(weather.temperature))°F")
                             .font(.footnote)
                     }
                     Button {

--- a/BnbTV/BnbTV/WeatherCardView.swift
+++ b/BnbTV/BnbTV/WeatherCardView.swift
@@ -11,6 +11,8 @@ struct WeatherCardView: View {
                 VStack(alignment: .leading, spacing: 8) {
                     Text(day.date, format: Date.FormatStyle().weekday(.abbreviated))
                         .font(.headline)
+                    Text(weatherEmoji(for: day.description))
+                        .font(.largeTitle)
                     Text(day.description)
                         .font(.subheadline)
                         .multilineTextAlignment(.leading)
@@ -20,7 +22,7 @@ struct WeatherCardView: View {
                 }
                 .padding()
                 .frame(width: 450, height: 220, alignment: .leading)
-                .background(Color.white.opacity(0.3))
+                .background(Color.blue.opacity(0.3))
                 .cornerRadius(10)
                 .tag(i)
             }

--- a/BnbTV/BnbTV/WeatherEmoji.swift
+++ b/BnbTV/BnbTV/WeatherEmoji.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+func weatherEmoji(for description: String) -> String {
+    switch description {
+    case "Clear": return "☀️"
+    case "Clouds": return "☁️"
+    case "Fog": return "🌫️"
+    case "Drizzle": return "🌦️"
+    case "Rain": return "🌧️"
+    case "Snow": return "❄️"
+    default: return "❓"
+    }
+}
+


### PR DESCRIPTION
## Summary
- display weather condition with emoji on home screen
- move rotating forecast to right side with transparent blue background
- centralize weather emoji mapping

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68b308c1f264832b9c56e7090df23279