### PR TITLE
Add toggleable weather and theme park cards

### DIFF
--- a/BnbTV/BnbTV/ContentView.swift
+++ b/BnbTV/BnbTV/ContentView.swift
@@ -47,6 +47,7 @@ struct ContentView: View {
     @AppStorage("homeMusic") private var homeMusicName: String = ""
     @AppStorage("buttonColor") private var buttonColorName: String = "transparentGrey"
     @AppStorage("showThemeParks") private var showThemeParks: Bool = true
+    @AppStorage("showWeather") private var showWeather: Bool = true
     @EnvironmentObject private var configManager: ConfigManager
 
     @AppStorage("isPasscodeEnabled") private var isPasscodeEnabled: Bool = false
@@ -75,6 +76,12 @@ struct ContentView: View {
         return formatter.string(from: currentDate)
     }
 
+    private var dateString: String {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .medium
+        return formatter.string(from: currentDate)
+    }
+
     var body: some View {
         NavigationStack {
             ZStack(alignment: .topTrailing) {
@@ -100,10 +107,17 @@ struct ContentView: View {
                             .frame(maxWidth: .infinity, alignment: .leading)
                     }
 
-                    if !forecast.isEmpty {
+                    if (showWeather && !forecast.isEmpty) || showThemeParks {
                         HStack {
                             Spacer()
-                            WeatherCardView(forecast: forecast)
+                            HStack(spacing: 20) {
+                                if showWeather && !forecast.isEmpty {
+                                    WeatherCardView(forecast: forecast)
+                                }
+                                if showThemeParks {
+                                    ThemeParkCardView()
+                                }
+                            }
                         }
                         .frame(maxWidth: .infinity)
                     }
@@ -139,9 +153,11 @@ struct ContentView: View {
                 .padding(.leading, 80)
 
                 VStack(alignment: .trailing, spacing: 4) {
+                    Text(dateString)
+                        .font(.footnote)
                     Text(timeString)
                         .font(.title3)
-                    if let weather = weather {
+                    if showWeather, let weather = weather {
                         Text("\(weatherEmoji(for: weather.description)) \(weather.description) \(Int(weather.temperature))°F")
                             .font(.footnote)
                     }
@@ -304,7 +320,7 @@ struct ContentView: View {
     }
 
     private func refreshWeather() async {
-        guard !zipCode.isEmpty else { return }
+        guard showWeather, !zipCode.isEmpty else { return }
         async let current = WeatherManager.shared.fetchWeather(for: zipCode)
         async let forecastData = WeatherManager.shared.fetchForecast(for: zipCode)
         weather = try? await current

--- a/BnbTV/BnbTV/SettingsView.swift
+++ b/BnbTV/BnbTV/SettingsView.swift
@@ -42,6 +42,7 @@ struct SettingsView: View {
     @AppStorage("isPasscodeEnabled") private var isPasscodeEnabled: Bool = false
     @AppStorage("settingsPasscode") private var settingsPasscode: String = ""
     @AppStorage("showThemeParks") private var showThemeParks: Bool = true
+    @AppStorage("showWeather") private var showWeather: Bool = true
 
     @EnvironmentObject private var configManager: ConfigManager
 
@@ -140,7 +141,8 @@ struct SettingsView: View {
             }
 
             Section("Home Screen") {
-                Toggle("Show Theme Parks Button", isOn: $showThemeParks)
+                Toggle("Show Weather", isOn: $showWeather)
+                Toggle("Show Theme Parks", isOn: $showThemeParks)
             }
 
             Section("Zip Code") {

--- a/BnbTV/BnbTV/ThemeParkCardView.swift
+++ b/BnbTV/BnbTV/ThemeParkCardView.swift
@@ -1,0 +1,29 @@
+import SwiftUI
+
+struct ThemeParkCardView: View {
+    var body: some View {
+        NavigationLink(destination: ThemeParkView()) {
+            ZStack {
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("Theme Parks")
+                        .font(.headline)
+                    Spacer()
+                    Image(systemName: "theatermasks")
+                        .resizable()
+                        .scaledToFit()
+                        .frame(height: 60)
+                    Spacer()
+                }
+                .padding()
+            }
+            .frame(width: 220, height: 220, alignment: .leading)
+            .background(Color.green.opacity(0.5))
+            .cornerRadius(25)
+        }
+        .buttonStyle(PlainButtonStyle())
+    }
+}
+
+#Preview {
+    ThemeParkCardView()
+}

--- a/BnbTV/BnbTV/WeatherCardView.swift
+++ b/BnbTV/BnbTV/WeatherCardView.swift
@@ -2,12 +2,10 @@ import SwiftUI
 
 struct WeatherCardView: View {
     let forecast: [ForecastDay]
-    @State private var index: Int = 0
-    private let timer = Timer.publish(every: 5, on: .main, in: .common).autoconnect()
 
     var body: some View {
-        TabView(selection: $index) {
-            ForEach(Array(forecast.prefix(3).enumerated()), id: \.offset) { i, day in
+        HStack(spacing: 20) {
+            ForEach(Array(forecast.prefix(3).enumerated()), id: \.offset) { _, day in
                 ZStack(alignment: .topTrailing) {
                     VStack(alignment: .leading, spacing: 8) {
                         Text(day.date, format: Date.FormatStyle().weekday(.abbreviated))
@@ -23,21 +21,12 @@ struct WeatherCardView: View {
                     }
                     .padding()
                     Text(day.date, format: Date.FormatStyle().day())
-                        .font(.system(size: 40, weight: .bold))
+                        .font(.system(size: 24, weight: .bold))
                         .padding(8)
                 }
-                .frame(width: 450, height: 220, alignment: .leading)
+                .frame(width: 220, height: 220, alignment: .leading)
                 .background(Color.blue.opacity(0.5))
                 .cornerRadius(25)
-                .tag(i)
-            }
-        }
-        .tabViewStyle(PageTabViewStyle(indexDisplayMode: .never))
-        .frame(width: 450, height: 220)
-        .onReceive(timer) { _ in
-            guard !forecast.isEmpty else { return }
-            withAnimation {
-                index = (index + 1) % min(forecast.count, 3)
             }
         }
     }


### PR DESCRIPTION
## Summary
- replace rotating weather view with three static forecast boxes
- allow users to toggle weather and theme park cards from settings
- show current date on home screen

## Testing
- `swift test` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*

------
https://chatgpt.com/codex/tasks/task_e_68b30e41edec832ba8bbd6f4cf6f2fb5